### PR TITLE
Upgrade to asciidoctor-diagram 2.0.3

### DIFF
--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=2.0.2
+version=2.0.3
 gem_name=asciidoctor-diagram

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.2
+version=2.0.3


### PR DESCRIPTION
A new version of asciidoctor-diagram has been released, let's keep this project it in-sync 

I updated both `gradle.properties` files, wasn't sure if I should change only one of them, and leave the second one for the final release. 