### PR TITLE
Split asciidoctorj-diagram according to split in asciidoctor-diagram

### DIFF
--- a/asciidoctorj-diagram-ditaamini/build.gradle
+++ b/asciidoctorj-diagram-ditaamini/build.gradle
@@ -1,0 +1,23 @@
+dependencies {
+  gems("rubygems:asciidoctor-diagram-ditaamini:${project.version}")
+}
+
+def gemFiles = fileTree("${project.buildDir}/.gems") {
+  include 'specifications/*.gemspec'
+  include 'gems/*/lib/**'
+}
+
+jrubyPrepare {
+  doLast {
+    println "Copy from $gemFiles into $preparedGems"
+    copy { // bundles the gems inside this artifact
+      from gemFiles
+      into preparedGems
+    }
+  }
+}
+
+ext.publicationName = "mavenAsciidoctorJDiagramDitaamini"
+
+apply from: rootProject.file('gradle/publish.gradle')
+apply from: rootProject.file('gradle/signing.gradle')

--- a/asciidoctorj-diagram-ditaamini/gradle.properties
+++ b/asciidoctorj-diagram-ditaamini/gradle.properties
@@ -1,0 +1,4 @@
+properName=AsciidoctorJ Diagram Ditaamini
+description=AsciidoctorJ Diagram Ditaamini bundles the Asciidoctor Diagram Ditaamini RubyGem (asciidoctor-diagram-ditaamini) so it can be loaded into the JVM using JRuby.
+version=1.0.0
+gem_name=asciidoctor-diagram-ditaamini

--- a/asciidoctorj-diagram-plantuml/build.gradle
+++ b/asciidoctorj-diagram-plantuml/build.gradle
@@ -1,0 +1,23 @@
+dependencies {
+  gems("rubygems:asciidoctor-diagram-plantuml:${project.version}")
+}
+
+def gemFiles = fileTree("${project.buildDir}/.gems") {
+  include 'specifications/*.gemspec'
+  include 'gems/*/lib/**'
+}
+
+jrubyPrepare {
+  doLast {
+    println "Copy from $gemFiles into $preparedGems"
+    copy { // bundles the gems inside this artifact
+      from gemFiles
+      into preparedGems
+    }
+  }
+}
+
+ext.publicationName = "mavenAsciidoctorJDiagramPlantuml"
+
+apply from: rootProject.file('gradle/publish.gradle')
+apply from: rootProject.file('gradle/signing.gradle')

--- a/asciidoctorj-diagram-plantuml/gradle.properties
+++ b/asciidoctorj-diagram-plantuml/gradle.properties
@@ -1,0 +1,5 @@
+properName=AsciidoctorJ Diagram Plantuml
+description=AsciidoctorJ Diagram Plantul bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
+version=1.2021.8
+gem_name=asciidoctor-diagram-plantuml
+

--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -3,10 +3,14 @@ dependencies {
   testCompile "org.jsoup:jsoup:$jsoupVersion"
   testCompile "org.asciidoctor:asciidoctorj:$asciidoctorJVersion"
 
+  implementation project(':asciidoctorj-diagram-plantuml')
+  implementation project(':asciidoctorj-diagram-ditaamini')
   gems("rubygems:asciidoctor-diagram:$asciidoctorDiagramGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'
+    exclude module: 'asciidoctor-diagram-plantuml'
+    exclude module: 'asciidoctor-diagram-ditaamini'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ ext {
   pdfboxVersion = '1.8.10'
 
   // gem versions
-  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '1.5.8'
+  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.4.3'
   asciidoctorDiagramGemVersion = project.hasProperty('asciidoctorDiagramGemVersion') ? project.asciidoctorDiagramGemVersion : project(':asciidoctorj-diagram').version.replace('-', '.')
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=2.1.2
+gem_name=asciidoctor-diagram

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,8 @@ rootProject.name = 'asciidoctorj-diagram'
 
 include \
   'asciidoctorj-diagram',
+  'asciidoctorj-diagram-plantuml',
+  'asciidoctorj-diagram-ditaamini',
   'itest'
 
 


### PR DESCRIPTION
According to the split of modules in asciidoctor-diagram into the "main" library and seperate gems for plantuml and ditaa, this PR tries to mimic the same for asciidoctorj-diagram.
I.e. there will be new jars for asciidoctorj-diagram-ditaamini and asciidoctorj-diagram-plantuml, that don't have any dependencies.
asciidoctorj-diagram itself will get dependencies on these 2 new jars.

The new jars are currently available for testing in the staging repo at https://oss.sonatype.org/content/repositories/orgasciidoctor-1268.