### PR TITLE
Raise minimum Java version to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,11 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['11', '17']
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
-            java: '8'
-          - os: macos-latest
             java: '17'
-          - os: windows-latest
-            java: '8'
           - os: windows-latest
             java: '17'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
             java: '17'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,12 @@ subprojects {
 
   status = _status
 
-  // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
-  // Must redefine here to work around a bug in the Eclipse plugin
-  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
+  project.tasks.withType(JavaCompile).configureEach { task ->
+    task.options.release = 11
+  }
+  project.tasks.withType(GroovyCompile).configureEach {task ->
+    task.options.release = 11
+  }
 
   repositories {
     if (project.hasProperty('useMavenLocal') && project.useMavenLocal.toBoolean()) {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   jrubyVersion = '9.2.4.0'
   junitVersion = '5.8.2'
   assertjVersion = '3.22.0'
-  jsoupVersion = '1.14.3'
+  jsoupVersion = '1.15.3'
 
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.3'
@@ -56,17 +56,17 @@ subprojects {
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
   // Must redefine here to work around a bug in the Eclipse plugin
-  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 
-  plugins.withType(JavaPlugin) {
-    project.tasks.withType(JavaCompile) { task ->
-      if (JavaVersion.current().isJava11Compatible()) {
-        task.options.release = 8
-      }
+  plugins.withType(JavaPlugin).configureEach {
+    project.tasks.withType(JavaCompile).configureEach { task ->
+      task.options.release = 11
     }
-    project.tasks.withType(GroovyCompile) { task ->
-      if (JavaVersion.current().isJava11Compatible()) {
-        task.options.release = 8
+    project.tasks.withType(GroovyCompile).tap {
+      configureEach { task ->
+        if (JavaVersion.current().isJava11Compatible()) {
+          task.options.release = 11
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -58,19 +58,6 @@ subprojects {
   // Must redefine here to work around a bug in the Eclipse plugin
   sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 
-  plugins.withType(JavaPlugin).configureEach {
-    project.tasks.withType(JavaCompile).configureEach { task ->
-      task.options.release = 11
-    }
-    project.tasks.withType(GroovyCompile).tap {
-      configureEach { task ->
-        if (JavaVersion.current().isJava11Compatible()) {
-          task.options.release = 11
-        }
-      }
-    }
-  }
-
   repositories {
     if (project.hasProperty('useMavenLocal') && project.useMavenLocal.toBoolean()) {
       mavenLocal()


### PR DESCRIPTION
Since asciidoctor-diagram is compiled for Java 11 since version 2.2.8, AsciidoctorJ-diagram has to do that as well.