### PR TITLE
Add barby and rqrcode gems for generating qrcodes

### DIFF
--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -2,9 +2,12 @@ dependencies {
 
   testImplementation "org.jsoup:jsoup:$jsoupVersion"
   testImplementation "org.asciidoctor:asciidoctorj:$asciidoctorJVersion"
+  testImplementation "org.jruby:jruby-complete:$jrubyVersion"
 
   implementation project(':asciidoctorj-diagram-plantuml')
   implementation project(':asciidoctorj-diagram-ditaamini')
+  gems("rubygems:barby:$barbyGemVersion")
+  gems("rubygems:rqrcode:$rqrcodeGemVersion")
   gems("rubygems:asciidoctor-diagram:$asciidoctorDiagramGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'

--- a/asciidoctorj-diagram/src/test/java/org.asciidoctor/WhenDocumentContainsQrcode.java
+++ b/asciidoctorj-diagram/src/test/java/org.asciidoctor/WhenDocumentContainsQrcode.java
@@ -1,0 +1,31 @@
+package org.asciidoctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenDocumentContainsQrcode {
+
+    private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+    @Test
+    public void png_should_be_rendered_for_qrcode() {
+        File sourceDir = new File("build/resources/test");
+        File inputFile = new File(sourceDir, "sampleqrcode.adoc");
+
+        File outputDiagram = new File(sourceDir, "testqrcode.png");
+        File outputDiagramCache = new File(sourceDir, ".asciidoctor/diagram/testqrcode.png.cache");
+
+        asciidoctor.requireLibrary("asciidoctor-diagram");
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
+                        .backend("html5")
+                        .toFile(new File(sourceDir, "sampleqrcode.html"))
+                        .build());
+
+        assertThat(outputDiagram).exists();
+        assertThat(outputDiagramCache).exists();
+    }
+}

--- a/asciidoctorj-diagram/src/test/resources/sampleqrcode.adoc
+++ b/asciidoctorj-diagram/src/test/resources/sampleqrcode.adoc
@@ -1,0 +1,8 @@
+= Document Title
+
+Scan this with your phone:
+
+[qrcode,testqrcode]
+----
+https://my-link.tld/something
+----

--- a/build.gradle
+++ b/build.gradle
@@ -31,14 +31,16 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  jrubyVersion = '9.2.4.0'
+  jrubyVersion = '9.4.2.0'
   junitVersion = '5.8.2'
   assertjVersion = '3.22.0'
   jsoupVersion = '1.15.3'
 
   // gem versions
-  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.3'
+  asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.10'
   asciidoctorDiagramGemVersion = project.hasProperty('asciidoctorDiagramGemVersion') ? project.asciidoctorDiagramGemVersion : project(':asciidoctorj-diagram').version.replace('-', '.')
+  barbyGemVersion = "0.6.8"
+  rqrcodeGemVersion = "2.2.0"
 }
 
 allprojects {
@@ -142,7 +144,7 @@ configure(subprojects.findAll { it.name != 'itest'}) {
   }
 
   jruby {
-    jrubyVersion = jrubyVersion
+    jrubyVersion = rootProject.jrubyVersion
   }
 
   ext {

--- a/licenses/THIRD_PARTY_LICENSES.adoc
+++ b/licenses/THIRD_PARTY_LICENSES.adoc
@@ -1,0 +1,75 @@
+= Third Party Licenses
+
+== asciidoctor-diagram
+
+Copyright (c) 2014 Pepijn Van Eeckhoudt
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+== barby
+
+Copyright (c) 2008 Tore Darell
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+== rqrcode
+
+The MIT License (MIT)
+
+Copyright (c) 2008 Duncan Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Fixes #34 

This PR bundles the barby and rqrcode gems to allow creating qrcodes from AsciidoctorJ.
Since I don't know the maintainers, and to be on the safe side, I started listing the third part licenses for these libs.