### PR TITLE
Upgrade asciidoctor-diagram-plantuml to 1.2023.12

### DIFF
--- a/asciidoctorj-diagram-plantuml/gradle.properties
+++ b/asciidoctorj-diagram-plantuml/gradle.properties
@@ -1,5 +1,5 @@
 properName=AsciidoctorJ Diagram Plantuml
-description=AsciidoctorJ Diagram Plantul bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
-version=1.2023.10
+description=AsciidoctorJ Diagram Plantuml bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
+version=1.2023.12
 gem_name=asciidoctor-diagram-plantuml
 


### PR DESCRIPTION
I've upgraded the asciidoctor-diagram-plantuml version as there a release of that new version some time ago, see https://github.com/asciidoctor/asciidoctor-diagram/issues/444

Could you please merge this PR and publish a release on Maven central? 

I built it locally and did a small smoke test, and it seems to work for me.