### PR TITLE
Upgrade to Asciidoctor Diagram 2.2.17

### DIFF
--- a/asciidoctorj-diagram-plantuml/gradle.properties
+++ b/asciidoctorj-diagram-plantuml/gradle.properties
@@ -1,5 +1,5 @@
 properName=AsciidoctorJ Diagram Plantuml
 description=AsciidoctorJ Diagram Plantuml bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
-version=1.2023.12
+version=1.2023.13
 gem_name=asciidoctor-diagram-plantuml
 

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=2.2.14
+version=2.2.17
 gem_name=asciidoctor-diagram

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.2.14
+version=2.2.17
 gem_name=asciidoctor-diagram


### PR DESCRIPTION
### Upgrade Asciidoctor Diagram and PlantUML

I would like to upgrade asciidoctor-diagram to 2.2.17 and asciidoctor-diagram-plantuml to 1.2023.13 in order to use the latest fixes and features from AsciidoctorJ and finally the IntelliJ plugin.

