### PR TITLE
Prepare v2.3.0 and migrate back to Java 8

### DIFF
--- a/asciidoctorj-diagram-plantuml/gradle.properties
+++ b/asciidoctorj-diagram-plantuml/gradle.properties
@@ -1,5 +1,5 @@
 properName=AsciidoctorJ Diagram Plantuml
 description=AsciidoctorJ Diagram Plantuml bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
-version=1.2023.13
+version=1.2024.0
 gem_name=asciidoctor-diagram-plantuml
 

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=2.2.17
+version=2.3.0
 gem_name=asciidoctor-diagram

--- a/build.gradle
+++ b/build.gradle
@@ -57,10 +57,10 @@ subprojects {
   status = _status
 
   project.tasks.withType(JavaCompile).configureEach { task ->
-    task.options.release = 11
+    task.options.release = 8
   }
   project.tasks.withType(GroovyCompile).configureEach {task ->
-    task.options.release = 11
+    task.options.release = 8
   }
 
   repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.2.17
+version=2.3.0
 gem_name=asciidoctor-diagram


### PR DESCRIPTION
This PR prepares for the release of asciidoctorj-diagram 2.3.0 and asciidoctorj-diagram-plantuml 1.2024.0.
The base version of Java is relaxed to Java 8 again.