### PR TITLE
asciidoctor-diagram 2.3.1 and asciidoctor-diagram-plantuml 1.2024.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,16 @@ on:
         type: boolean
         default: true
         required: true
+      publishAsciidoctorJDiagramBatik:
+        description: "Publish asciidoctorj-diagram-batik"
+        type: boolean
+        default: true
+        required: true
+      publishAsciidoctorJDiagramJSyntrax:
+        description: "Publish asciidoctorj-diagram-jsyntrax"
+        type: boolean
+        default: true
+        required: true
 
 env:
   ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.GPG_KEY_ID }}
@@ -42,6 +52,8 @@ jobs:
           if ${{ inputs.publishAsciidoctorJDiagram }}; then GOALS="publishMavenAsciidoctorJDiagramPublicationToSonatypeRepository "; fi
           if ${{ inputs.publishAsciidoctorJDiagramDitaaMini }}; then GOALS="$GOALS publishMavenAsciidoctorJDiagramDitaaminiPublicationToSonatypeRepository "; fi
           if ${{ inputs.publishAsciidoctorJDiagramPlantuml }}; then GOALS="$GOALS publishMavenAsciidoctorJDiagramPlantumlPublicationToSonatypeRepository "; fi
+          if ${{ inputs.publishAsciidoctorJDiagramBatik }}; then GOALS="$GOALS publishMavenAsciidoctorJDiagramBatikPublicationToSonatypeRepository "; fi
+          if ${{ inputs.publishAsciidoctorJDiagramJSyntrax }}; then GOALS="$GOALS publishMavenAsciidoctorJDiagramJSyntraxPublicationToSonatypeRepository "; fi
           echo "Publishing goals: ${GOALS}"
           unset GEM_PATH GEM_HOME JRUBY_OPTS
           ./gradlew --no-daemon clean build

--- a/asciidoctorj-diagram-batik/build.gradle
+++ b/asciidoctorj-diagram-batik/build.gradle
@@ -1,8 +1,5 @@
 dependencies {
-  gems("rubygems:asciidoctor-diagram-plantuml:${project.version}") {
-    exclude module: "asciidoctor-diagram-batik"
-  }
-  implementation project(':asciidoctorj-diagram-batik')
+  gems("rubygems:asciidoctor-diagram-batik:${project.version}")
 }
 
 def gemFiles = fileTree("${project.buildDir}/.gems") {
@@ -20,7 +17,7 @@ jrubyPrepare {
   }
 }
 
-ext.publicationName = "mavenAsciidoctorJDiagramPlantuml"
+ext.publicationName = "mavenAsciidoctorJDiagramBatik"
 
 apply from: rootProject.file('gradle/publish.gradle')
 apply from: rootProject.file('gradle/signing.gradle')

--- a/asciidoctorj-diagram-batik/gradle.properties
+++ b/asciidoctorj-diagram-batik/gradle.properties
@@ -1,0 +1,4 @@
+properName=AsciidoctorJ Diagram Batik
+description=AsciidoctorJ Diagram Batik bundles the Asciidoctor Diagram Batik RubyGem (asciidoctor-diagram-batik) so it can be loaded into the JVM using JRuby.
+version=1.17
+gem_name=asciidoctor-diagram-batik

--- a/asciidoctorj-diagram-jsyntrax/build.gradle
+++ b/asciidoctorj-diagram-jsyntrax/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  gems("rubygems:asciidoctor-diagram-plantuml:${project.version}") {
+  gems("rubygems:asciidoctor-diagram-jsyntrax:${project.version}") {
     exclude module: "asciidoctor-diagram-batik"
   }
   implementation project(':asciidoctorj-diagram-batik')

--- a/asciidoctorj-diagram-jsyntrax/gradle.properties
+++ b/asciidoctorj-diagram-jsyntrax/gradle.properties
@@ -1,0 +1,5 @@
+properName=AsciidoctorJ Diagram JSyntrax
+description=AsciidoctorJ Diagram JSyntrax bundles the Asciidoctor Diagram JSyntrax RubyGem (asciidoctor-diagram-jsyntrax) so it can be loaded into the JVM using JRuby.
+version=1.38.1
+gem_name=asciidoctor-diagram-jsyntrax
+

--- a/asciidoctorj-diagram-plantuml/build.gradle
+++ b/asciidoctorj-diagram-plantuml/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
-  gems("rubygems:asciidoctor-diagram-plantuml:${project.version}")
+  gems("rubygems:asciidoctor-diagram-plantuml:${project.version}") {
+    // Version resolution does not seem to work correctly for this one, therefore requiring it explicitly
+    exclude module: "asciidoctor-diagram-batik"
+  }
+  gems("rubygems:asciidoctor-diagram-batik:${asciidoctorDiagramBatikGemVersion}")
 }
 
 def gemFiles = fileTree("${project.buildDir}/.gems") {

--- a/asciidoctorj-diagram-plantuml/gradle.properties
+++ b/asciidoctorj-diagram-plantuml/gradle.properties
@@ -1,5 +1,5 @@
 properName=AsciidoctorJ Diagram Plantuml
 description=AsciidoctorJ Diagram Plantuml bundles the Asciidoctor Diagram Plantuml RubyGem (asciidoctor-diagram-plantuml) so it can be loaded into the JVM using JRuby.
-version=1.2024.3
+version=1.2024.5
 gem_name=asciidoctor-diagram-plantuml
 

--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -12,9 +12,11 @@ dependencies {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
     exclude module: 'thread_safe'
+    exclude module: 'rexml'
     exclude module: 'asciidoctor-diagram-plantuml'
     exclude module: 'asciidoctor-diagram-ditaamini'
   }
+  gems("rubygems:rexml:$rexmlGemVersion")
 }
 
 def gemFiles = fileTree("${project.buildDir}/.gems") {

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=2.3.0
+version=2.3.1
 gem_name=asciidoctor-diagram

--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,16 @@ subprojects {
 
   status = _status
 
+  def _javaVersion = 8
+  if (project.name == "itest"
+          || project.name == "asciidoctorj-diagram-jsyntrax") {
+    _javaVersion = 11
+  }
   project.tasks.withType(JavaCompile).configureEach { task ->
-    task.options.release = 8
+    task.options.release = _javaVersion
   }
   project.tasks.withType(GroovyCompile).configureEach {task ->
-    task.options.release = 8
+    task.options.release = _javaVersion
   }
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -31,16 +31,18 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  jrubyVersion = '9.4.2.0'
+  jrubyVersion = '9.4.7.0'
   junitVersion = '5.8.2'
   assertjVersion = '3.22.0'
-  jsoupVersion = '1.15.3'
+  jsoupVersion = '1.17.2'
 
   // gem versions
   asciidoctorJVersion = project.hasProperty('asciidoctorJVersion') ? project.asciidoctorJVersion : '2.5.10'
   asciidoctorDiagramGemVersion = project.hasProperty('asciidoctorDiagramGemVersion') ? project.asciidoctorDiagramGemVersion : project(':asciidoctorj-diagram').version.replace('-', '.')
-  barbyGemVersion = "0.6.8"
+  asciidoctorDiagramBatikGemVersion = "1.17"
+  barbyGemVersion = "0.6.9"
   rqrcodeGemVersion = "2.2.0"
+  rexmlGemVersion = '3.2.6'
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.3.0
+version=2.3.1
 gem_name=asciidoctor-diagram

--- a/itest/build.gradle
+++ b/itest/build.gradle
@@ -3,10 +3,11 @@ dependencies {
     testImplementation ("org.asciidoctor:asciidoctorj:$asciidoctorJVersion")
 
     testImplementation project(':asciidoctorj-diagram')
+    testImplementation project(':asciidoctorj-diagram-jsyntrax')
 }
 
 jar.enabled = false
 
-configurations.all {
+configurations.configureEach {
     artifacts.clear()
 }

--- a/itest/src/test/java/org.asciidoctor/WhenDocumentContainsDiagrams.java
+++ b/itest/src/test/java/org.asciidoctor/WhenDocumentContainsDiagrams.java
@@ -6,9 +6,9 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WhenDocumentContainsDitaaDiagram {
+public class WhenDocumentContainsDiagrams {
 
-    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+    private final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
     @Test
     public void png_should_be_rendered_for_diagram() {
@@ -19,10 +19,22 @@ public class WhenDocumentContainsDitaaDiagram {
         File expectedDiagram = new File(sourceDir, "asciidoctor-diagram-process.png");
         File expectedDiagramCache = new File(sourceDir, ".asciidoctor/diagram/asciidoctor-diagram-process.png.cache");
 
+        File expectedPlantumlDiagram = new File(sourceDir, "plantuml-test.svg");
+        File expectedPlantumlDiagramCache = new File(sourceDir, ".asciidoctor/diagram/plantuml-test.svg.cache");
+
+        File expectedJSyntraxDiagram = new File(sourceDir, "jsyntrax-test.svg");
+        File expectedJSyntraxDiagramCache = new File(sourceDir, ".asciidoctor/diagram/jsyntrax-test.svg.cache");
+
         asciidoctor.requireLibrary("asciidoctor-diagram");
         asciidoctor.convertFile(sourceDocument, Options.builder().backend("html5").build());
 
         assertThat(expectedDiagram).isNotEmpty();
         assertThat(expectedDiagramCache).isNotEmpty();
+
+        assertThat(expectedPlantumlDiagram).isNotEmpty();
+        assertThat(expectedPlantumlDiagramCache).isNotEmpty();
+
+        assertThat(expectedJSyntraxDiagram).isNotEmpty();
+        assertThat(expectedJSyntraxDiagramCache).isNotEmpty();
     }
 }

--- a/itest/src/test/resources/sample.adoc
+++ b/itest/src/test/resources/sample.adoc
@@ -20,3 +20,18 @@
      +-----------------------------------+
 ....
 
+[plantuml,plantuml-test,svg]
+----
+class A
+class B
+A --> B
+----
+
+[syntrax,jsyntrax-test,svg]
+----
+indentstack(10,
+  line(opt('-'), choice('0', line('1-9', loop(None, '0-9'))),
+    opt('.', loop('0-9', None))),
+  line(opt(choice('e', 'E'), choice(None, '+', '-'), loop('0-9', None)))
+)
+----

--- a/licenses/THIRD_PARTY_LICENSES.adoc
+++ b/licenses/THIRD_PARTY_LICENSES.adoc
@@ -73,3 +73,296 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+== jsyntrax
+
+MIT License
+
+Copyright (c) 2020 The department of the Algorithms and programming technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+== xmlgraphics-common
+
+Apache XML Graphics Commons
+Copyright 2006-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+== xml-apis
+
+This distribution includes xml-apis.jar from the XML Commons External
+1.4.01 binary distribution, which can also be obtained from:
+
+  http://xml.apache.org/mirrors.cgi
+
+Source code is available from the XML Commons web site:
+
+  http://xml.apache.org/commons/
+
+xml-apis.jar contains:
+
+- DOM Level 2 Events
+- DOM Level 2 HTML
+- DOM Level 2 Style
+- DOM Level 2 Traversal and Range
+- DOM Level 2 Views
+- DOM Level 3 Core
+- DOM Level 3 Load and Save
+- DOM Level 3 XPath
+- JAXP 1.3 (JSR 206)
+- SAX
+
+All DOM code is licensed under the W3C Software License, and DOM documentation
+under the W3C Document License.  See LICENSE.dom-software.txt and
+LICENSE.dom-documentation.txt.
+
+The JAXP 1.3 code is licensed under the Apache Software License 2.0, which is
+in the LICENSE in the root directory of this distribution.
+
+SAX is public domain.  See LICENSE.sax.txt.
+
+== xml-apis-ext
+
+This distribution includes xml-apis-ext.jar from the XML Commons External
+1.3.04 binary distribution, which can also be obtained from:
+
+  http://xml.apache.org/mirrors.cgi
+
+Source code is available from the XML Commons web site:
+
+  http://xml.apache.org/commons/
+
+xml-apis-ext.jar contains:
+
+- SAC 1.3
+- SMIL Java bindings
+- SVG 1.1 Java bindings
+
+SAC 1.3, the SMIL Java bindings and the SVG 1.1 Java bindings are licensed
+under the W3C Software License.  Related documentation is licensed under the
+W3C Document License.  See LICENSE.dom-software.txt and
+LICENSE.dom-documentation.txt.
+
+== batik
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,8 @@ include \
   'asciidoctorj-diagram',
   'asciidoctorj-diagram-plantuml',
   'asciidoctorj-diagram-ditaamini',
+  'asciidoctorj-diagram-batik',
+  'asciidoctorj-diagram-jsyntrax',
   'itest'
 
 


### PR DESCRIPTION
This PR upgrades asciidoctor-diagram and asciidoctor-diagram-plantuml to the latest versions.

I made some observations while preparing this PR:
- I also tried to upgrade Gradle to 8.8, but I experienced some errors from the jruby-gradle plugin, like this:
   ```
   exception thrown for request to /rubygems/rexml/3.2.6/ivy.xml
   java.lang.NoClassDefFoundError: Lorg/gradle/wrapper/ExclusiveFileAccessManager;
        at java.base/java.lang.Class.getDeclaredFields0(Native Method)
        at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3061)
        at java.base/java.lang.Class.getDeclaredFields(Class.java:2248)
        at org.codehaus.groovy.reflection.CachedClass$1.lambda$initValue$2(CachedClass.java:59)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at org.codehaus.groovy.reflection.CachedClass$1.initValue(CachedClass.java:62)
        at org.codehaus.groovy.reflection.CachedClass$1.initValue(CachedClass.java:54)
        at org.codehaus.groovy.util.LazyReference.getLocked(LazyReference.java:50)
        at org.codehaus.groovy.util.LazyReference.get(LazyReference.java:37)
        at org.codehaus.groovy.reflection.CachedClass.getFields(CachedClass.java:256)
        at groovy.lang.MetaClassImpl.addFields(MetaClassImpl.java:2488)
        at groovy.lang.MetaClassImpl.inheritFields(MetaClassImpl.java:2483)
        at groovy.lang.MetaClassImpl.setupProperties(MetaClassImpl.java:2369)
        at groovy.lang.MetaClassImpl.addProperties(MetaClassImpl.java:3409)
        at groovy.lang.MetaClassImpl.reinitialize(MetaClassImpl.java:3383)
        at groovy.lang.MetaClassImpl.initialize(MetaClassImpl.java:3376)
        at org.codehaus.groovy.reflection.ClassInfo.getMetaClassUnderLock(ClassInfo.java:273)
        at org.codehaus.groovy.reflection.ClassInfo.getMetaClass(ClassInfo.java:315)
        at org.ysb33r.grolifant.api.ExclusiveFileAccess.$getStaticMetaClass(ExclusiveFileAccess.groovy)
        at org.ysb33r.grolifant.api.ExclusiveFileAccess.<init>(ExclusiveFileAccess.groovy)
        at com.github.jrubygradle.internal.core.AbstractIvyXmlProxyServer.createIvyXml(AbstractIvyXmlProxyServer.groovy:116)
        at com.github.jrubygradle.internal.core.AbstractIvyXmlProxyServer.getIvyXml(AbstractIvyXmlProxyServer.groovy:155)
        at com.github.jrubygradle.internal.core.IvyXmlRatpackProxyServer.lambda$null$0(IvyXmlRatpackProxyServer.java:76)
   ```
- I also had to pin rexml to version 3.2.6 instead of using 3.3.0, like it was done for asciidoctor-pdf, otherwise it would complain at runtime about a version mismatch.
- asciidoctor-diagram-batik could not be resolved transitively, therefore I had to add a direct dependency. I saw this error locally. I cannot tell where this problem is rooted, but adding a direct dependency solved it for me:
   ```
   * What went wrong:
   Execution failed for task ':asciidoctorj-diagram-plantuml:jrubyPrepare'.
   > Could not resolve all files for configuration ':asciidoctorj-diagram-plantuml:gems'.
      > Could not find any version that matches rubygems:asciidoctor-diagram-batik:[1.17.0,2.0[.
        Versions that do not match: 1.17
        Searched in the following locations:
          - https://repo.maven.apache.org/maven2/rubygems/asciidoctor-diagram-batik/maven-metadata.xml
          - http://localhost:56135/rubygems/asciidoctor-diagram-batik/
        Required by:
            project :asciidoctorj-diagram-plantuml > rubygems:asciidoctor-diagram-plantuml:1.2024.5
   ```